### PR TITLE
explicitly list pandas as dependency in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
   numpy
   xarray
   xarray-extras
+  pandas
 
 # Add here test requirements (semicolon-separated)
 tests_require = pytest; pytest-cov


### PR DESCRIPTION
pandas is imported in several places, but not listed explicitly as dependency
it is an indirect dependency, but it's safer to make this explicit