### PR TITLE
Eliminate pandas dependency

### DIFF
--- a/src/openeo_processes/comparison.py
+++ b/src/openeo_processes/comparison.py
@@ -1,7 +1,7 @@
 import datetime
-import numpy as np
-import pandas as pd
+import math
 
+import numpy as np
 from openeo_processes.utils import process
 from openeo_processes.utils import str2time
 
@@ -22,10 +22,7 @@ def is_empty(data):
         True if object is emtpy, False if not.
 
     """
-    if len(data) == 0:
-        return True
-    else:
-        return False
+    return len(data) == 0
 
 
 ########################################################################################################################
@@ -91,15 +88,15 @@ class IsNodata:
         Attention! Since None values are not supported NumPy and Pandas, this method has the same behaviour as `is_nan`.
 
         """
-        return pd.isnull(x)
+        return IsNodata.exec_num(x)
 
     @staticmethod
-    def exec_xar():
-        pass
+    def exec_xar(x):
+        return IsNodata.exec_num(x)
 
     @staticmethod
-    def exec_da():
-        pass
+    def exec_da(x):
+        return IsNodata.exec_num(x)
 
 
 ########################################################################################################################
@@ -144,7 +141,7 @@ class IsNan:
             True if the data is a not a number, otherwise False.
 
         """
-        return np.isnan(x) if isinstance(x, (float, int)) else True
+        return (not isinstance(x, (int, float))) or math.isnan(x)
 
     @staticmethod
     def exec_np(x):
@@ -163,15 +160,15 @@ class IsNan:
             True if the data is a not a number, otherwise False.
 
         """
-        return pd.isnull(x)
+        return IsNan.exec_num(x)
 
     @staticmethod
-    def exec_xar():
-        pass
+    def exec_xar(x):
+        return IsNan.exec_num(x)
 
     @staticmethod
-    def exec_da():
-        pass
+    def exec_da(x):
+        return IsNan.exec_num(x)
 
 
 ########################################################################################################################
@@ -218,10 +215,11 @@ class IsValid:
             True if the data is valid, otherwise False.
 
         """
-        if x not in [np.nan, np.inf, None]:
-            return True
-        else:
+        if x is None:
             return False
+        elif isinstance(x, float):
+            return not (math.isnan(x) or math.isinf(x))
+        return True
 
     @staticmethod
     def exec_np(x):
@@ -242,18 +240,15 @@ class IsValid:
             True if the data is valid, otherwise False.
 
         """
-        if is_empty(x):
-            return False
-        else:
-            return ~pd.isnull(x) & (x != np.inf)
+        return IsValid.exec_num(x)
 
     @staticmethod
-    def exec_xar():
-        pass
+    def exec_xar(x):
+        return IsValid.exec_num(x)
 
     @staticmethod
-    def exec_da():
-        pass
+    def exec_da(x):
+        return IsValid.exec_num(x)
 
 
 ########################################################################################################################

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,26 +1,63 @@
 import unittest
+
+import numpy as np
 import openeo_processes as oeop
+import pytest
+
+
+@pytest.mark.parametrize(["value", "expected"], [
+    # Based on https://github.com/Open-EO/openeo-processes/issues/189
+    (None, True),
+    (np.nan, True),
+    (0, False),
+    (1, False),
+    (np.inf, False),
+    ("a string", True),
+    ([1, 2], True),
+    ([None, None], True),
+    ([np.nan, np.nan], True),
+])
+def test_is_nan(value, expected):
+    """ Tests `is_nan` function. """
+    assert oeop.is_nan(value) == expected
+
+
+@pytest.mark.parametrize(["value", "expected"], [
+    # Based on https://github.com/Open-EO/openeo-processes/issues/189
+    (None, True),
+    (np.nan, False),
+    (0, False),
+    (1, False),
+    (np.inf, False),
+    ("a string", False),
+    ([1, 2], False),
+    ([None, None], False),
+    ([np.nan, np.nan], False),
+])
+def test_is_nodata(value, expected):
+    """ Tests `is_nodata` function. """
+    assert oeop.is_nodata(value) == expected
+
+
+@pytest.mark.parametrize(["value", "expected"], [
+    # Based on https://github.com/Open-EO/openeo-processes/issues/189
+    (None, False),
+    (np.nan, False),
+    (0, True),
+    (1, True),
+    (np.inf, False),
+    ("a string", True),
+    ([1, 2], True),
+    ([None, None], True),
+    ([np.nan, np.nan], True),
+])
+def test_is_valid(value, expected):
+    """ Tests `is_valid` function. """
+    assert oeop.is_valid(value) == expected
 
 
 class ComparisonTester(unittest.TestCase):
     """ Tests all comparison functions. """
-
-    def test_is_nan(self):
-        """ Tests `is_nan` function. """
-        assert not oeop.is_nan(1)
-        assert oeop.is_nan('Test')
-
-    def test_is_nodata(self):
-        """ Tests `is_nodata` function. """
-        assert not oeop.is_nodata(1)
-        assert not oeop.is_nodata('Test')
-        assert oeop.is_nodata(None)
-
-    def test_is_valid(self):
-        """ Tests `is_valid` function. """
-        assert oeop.is_valid(1)
-        assert oeop.is_valid('Test')
-        assert not oeop.is_valid(None)
 
     def test_eq(self):
         """ Tests `eq` function. """


### PR DESCRIPTION
Related to issue #5 :
openeo-process-python has a dependency on pandas, but only seems to use `pandas.isnull()`. That's quite a heavy dependency for something that can probably be covered with a simple internal utility function.

This PR is for eliminating the pandas dependency

