### PR TITLE
add `get_process` to get process function by name (as string)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
+venv*/
 
 # folder including testing scripts
 .scripts

--- a/src/openeo_processes/__init__.py
+++ b/src/openeo_processes/__init__.py
@@ -13,3 +13,4 @@ from openeo_processes.arrays import *
 from openeo_processes.comparison import *
 from openeo_processes.math import *
 from openeo_processes.texts import *
+from openeo_processes.utils import get_process, has_process

--- a/src/openeo_processes/utils.py
+++ b/src/openeo_processes/utils.py
@@ -82,7 +82,8 @@ def process(processor):
 
         return cls_fun(*args, **kwargs)
 
-    _processes[processor.__name__] = fun_wrapper
+    process_id = processor.__name__.rstrip('_')
+    _processes[process_id] = fun_wrapper
 
     return fun_wrapper
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,12 +32,22 @@ def test_has_process():
     assert has_process("add")
     assert has_process("multiply")
     assert not has_process("foobar")
+    assert has_process("and")
+    assert not has_process("and_")
+    assert has_process("or")
+    assert not has_process("or_")
+    assert has_process("if")
+    assert not has_process("if_")
 
 
-def test_get_process():
-    fun = get_process("add")
-    assert fun(2, 3) == 5
-    fun = get_process("multiply")
-    assert fun(2, 3) == 6
-    fun = get_process("sum")
-    assert fun([1, 2, 3, 4, 5, 6]) == 21
+@pytest.mark.parametrize(["pid", "args", "expected"], [
+    ("add", (2, 3), 5),
+    ("multiply", (2, 3), 6),
+    ("sum", ([1, 2, 3, 4, 5, 6],), 21),
+    ("median", ([2, 5, 3, 8, 11],), 5),
+    ("and", (False, True), False),
+    ("or", (False, True), True),
+])
+def test_get_process(pid, args, expected):
+    fun = get_process(pid)
+    assert fun(*args) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import dask.array.core
 import numpy as np
 import pytest
 import xarray
-from openeo_processes.utils import eval_datatype
+from openeo_processes.utils import eval_datatype, get_process, has_process
 
 
 @pytest.mark.parametrize(["data", "expected"], [
@@ -26,3 +26,18 @@ from openeo_processes.utils import eval_datatype
 ])
 def test_eval_datatype(data, expected):
     assert eval_datatype(data) == expected
+
+
+def test_has_process():
+    assert has_process("add")
+    assert has_process("multiply")
+    assert not has_process("foobar")
+
+
+def test_get_process():
+    fun = get_process("add")
+    assert fun(2, 3) == 5
+    fun = get_process("multiply")
+    assert fun(2, 3) == 6
+    fun = get_process("sum")
+    assert fun([1, 2, 3, 4, 5, 6]) == 21


### PR DESCRIPTION
Addresses #10 :  adds a function `get_process` that allows you to get a process function by name/id.
See tests for example usage