### PR TITLE
Fix failing `count` tests

### DIFF
--- a/src/openeo_processes/arrays.py
+++ b/src/openeo_processes/arrays.py
@@ -274,16 +274,14 @@ class Count:
 
         """
         if condition is None:
-            count = np.sum(is_valid(data), axis=dimension)
-        elif condition is True: # explicit check needed
+            condition = is_valid
+        if condition is True: # explicit check needed
             count = data.shape[dimension]
         elif callable(condition):
             context = context if context is not None else {}
-            data = condition(data, **context)
-            count = np.sum(data, axis=dimension)
+            count = sum(1 for x in data if condition(x, **context))
         else:
-            err_msg = "Data type of condition is not supported."
-            raise ValueError(err_msg)
+            raise ValueError(condition)
 
         return count
 

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -49,10 +49,12 @@ class ArrayTester(unittest.TestCase):
     def test_count(self):
         """ Tests `count` function. """
         assert oeop.count([]) == 0
+        assert oeop.count([], condition=True) == 0
         assert oeop.count([1, 0, 3, 2]) == 4
         assert oeop.count(["ABC", np.nan]) == 1
         assert oeop.count([False, np.nan], condition=True) == 2
-        assert oeop.count([0, 1, 2, 3, 4, 5, np.nan], condition=oeop.gt, context={'y': 2})
+        assert oeop.count([0, 1, 2, 3, 4, 5, np.nan], condition=oeop.gt, context={'y': 2}) == 3
+        assert oeop.count([0, 1, 2, 3, 4, 5, np.nan], condition=oeop.lte, context={'y': 2}) == 3
 
     #TODO: add test
     def test_array_apply(self):


### PR DESCRIPTION
After merge of #12 the tests for `count` started failing I think

this PR fixes that

side-question: what is the point of the `dimension` argument in `Count.exec_np`? It is not part of the official spec of `count`