### PR TITLE
Start using Travis-CI for automated running of unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - 3.6
+  - 3.7
+  - 3.8
+install:
+  - pip install -e .[dask,xarray]
+script:
+  - python setup.py test


### PR DESCRIPTION
This PR adds an initial .travis.yml file for automated running of the unit tests through https://travis-ci.org/