### PR TITLE
Improved save_result

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
   pandas
 
 # Add here test requirements (semicolon-separated)
-tests_require = pytest; pytest-cov; dask; xarray; xarray-extras; rioxarray
+tests_require = pytest; pytest-cov; dask; xarray; xarray-extras; rioxarray; scipy
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
   pandas
 
 # Add here test requirements (semicolon-separated)
-tests_require = pytest; pytest-cov; dask; xarray; xarray-extras
+tests_require = pytest; pytest-cov; dask; xarray; xarray-extras; rioxarray
 
 [options.packages.find]
 where = src

--- a/src/openeo_processes/cubes.py
+++ b/src/openeo_processes/cubes.py
@@ -232,7 +232,7 @@ def save_result():
 
 class SaveResult:
     """
-    Class implementing all 'reduce_dimension' processes.
+    Class implementing 'save_result' processe.
 
     """
 
@@ -252,9 +252,36 @@ class SaveResult:
             data format (default: GTiff)
 
         """
-
+        
+        def refactor_data(data):
+            # The following code is required to recreate a Dataset from the final result as Dataarray, to get a well formatted netCDF
+            if 'time' in data.coords:
+                tmp = xr.Dataset(coords={'t':data.time.values,'y':data.y,'x':data.x})
+                if 'bands' in data.coords:
+                    try:
+                        for var in data['bands'].values:
+                            tmp[str(var)] = (('t','y','x'),data.loc[dict(bands=var)])
+                    except Exception as e:
+                        print(e)
+                        tmp[str((data['bands'].values))] = (('t','y','x'),data)
+                else:
+                    tmp['result'] = (('t','y','x'),data)
+            else:
+                tmp = xr.Dataset(coords={'y':data.y,'x':data.x})
+                if 'bands' in data.coords:
+                    try:
+                        for var in data['bands'].values:
+                            tmp[str(var)] = (('y','x'),data.loc[dict(bands=var)])
+                    except Exception as e:
+                        print(e)
+                        tmp[str((data['bands'].values))] = (('y','x'),data)
+                else:
+                    tmp['result'] = (('y','x'),data)
+            tmp.attrs = data.attrs
+            return tmp
+        
         formats = ('GTiff', 'netCDF')
-        if format == 'netCDF':
+        if format.lower() == 'netcdf':
             if not splitext(output_filepath)[1]:
                 output_filepath = output_filepath + '.nc'
             # start workaround
@@ -263,12 +290,26 @@ class SaveResult:
             if hasattr(data, 'time') and hasattr(data.time, 'units'):
                 data.time.attrs.pop('units', None)
             # end workaround
+            
+            data = refactor_data(data)
             data.to_netcdf(path=output_filepath)
-        elif format == 'GTiff':
+
+        elif format.lower() in ['gtiff','gtif','geotiff','geotif','tiff','tif']:
             if not splitext(output_filepath)[1]:
                 output_filepath = output_filepath + '.tif'
             # TODO
             # Add check, this works only for 2D or 3D DataArrays, else loop is needed
-            data.rio.to_raster(raster_path=output_filepath, driver=format, **options)
+            
+            data = refactor_data(data)
+            if len(data.dims) > 3:
+                if len(data.t)==1:
+                    # We keep the time variable as band in the GeoTiff, multiple band/variables of the same timestamp
+                    data = data.squeeze('time')
+                else:
+                    raise Exception("[!] Not possible to write a 4-dimensional GeoTiff, use NetCDF instead.")
+            
+            data.rio.to_raster(raster_path=output_filepath,**options)
+
+            
         else:
             raise ValueError(f"Error when saving to file. Format '{format}' is not in {formats}.")

--- a/src/openeo_processes/cubes.py
+++ b/src/openeo_processes/cubes.py
@@ -294,7 +294,7 @@ class SaveResult:
             data = refactor_data(data)
             data.to_netcdf(path=output_filepath)
 
-        elif format.lower() in ['gtiff','gtif','geotiff','geotif','tiff','tif']:
+        elif format.lower() in ['gtiff','geotiff']:
             if not splitext(output_filepath)[1]:
                 output_filepath = output_filepath + '.tif'
             # TODO

--- a/src/openeo_processes/cubes.py
+++ b/src/openeo_processes/cubes.py
@@ -305,7 +305,7 @@ class SaveResult:
             if len(data.dims) > 3:
                 if len(data.t)==1:
                     # We keep the time variable as band in the GeoTiff, multiple band/variables of the same timestamp
-                    data = data.squeeze('time')
+                    data = data.squeeze('t')
                 else:
                     raise Exception("[!] Not possible to write a 4-dimensional GeoTiff, use NetCDF instead.")
             

--- a/src/openeo_processes/cubes.py
+++ b/src/openeo_processes/cubes.py
@@ -2,6 +2,7 @@
 import rioxarray  # needed by save_result even if not directly called
 from openeo_processes.utils import process
 from os.path import splitext
+import xarray as xr
 
 ###############################################################################
 # Load Collection Process

--- a/src/openeo_processes/math.py
+++ b/src/openeo_processes/math.py
@@ -2,6 +2,7 @@ import builtins
 import numpy as np
 import numbers
 import xarray as xr
+import scipy.ndimage
 
 try:
     import xarray_extras as xar_addons

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,13 @@ def test_data(request):
         def __init__(self):
             self.steps = {'y': 5, 'x': 3}
             self.coords_4d = {
-                's': ['B08', 'B04', 'B02'],
-                't': [datetime(2019, 12, 1), datetime(2019, 12, 5)],
+                'bands': ['B08', 'B04', 'B02'],
+                'time': [datetime(2019, 12, 1), datetime(2019, 12, 5)],
                 'y': np.arange(55.3, 55.3 + self.steps['y']),
                 'x': np.arange(118.9, 118.9 + self.steps['x'])
             }
             self.coords_3d = {
-                't': [datetime(2019, 12, 1), datetime(2019, 12, 5)],
+                'time': [datetime(2019, 12, 1), datetime(2019, 12, 5)],
                 'y': np.arange(55.3, 55.3 + self.steps['y']),
                 'x': np.arange(118.9, 118.9 + self.steps['x'])
             }

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -52,10 +52,10 @@ class ArrayTester(TestCase):
 
         # xarray tests
         xr.testing.assert_equal(
-            oeop.array_element(self.test_data.xr_data_4d, dimension='s', label="B08"),
+            oeop.array_element(self.test_data.xr_data_4d, dimension='bands', label="B08"),
             self.test_data.xr_data_3d)
         xr.testing.assert_equal(
-            oeop.array_element(self.test_data.xr_data_4d, dimension='s', index=0),
+            oeop.array_element(self.test_data.xr_data_4d, dimension='bands', index=0),
             self.test_data.xr_data_3d)
         # Assert raised errors?
         # ArrayElementNotAvailable

--- a/tests/test_cubes.py
+++ b/tests/test_cubes.py
@@ -7,6 +7,7 @@ import os
 import unittest
 import pytest
 import openeo_processes as oeop
+import xarray as xr
 
 
 @pytest.mark.usefixtures("test_data")
@@ -19,7 +20,7 @@ class CubesTester(unittest.TestCase):
         # xarray tests
         # Reduce spectral dimension using the process `sum`
         # Take sum over 's' dimension in a 4d array
-        reduced = oeop.reduce_dimension(self.test_data.xr_data_4d, reducer=oeop.sum, dimension='s')
+        reduced = oeop.reduce_dimension(self.test_data.xr_data_4d, reducer=oeop.sum, dimension='bands')
         self.assertListEqual(
             list(reduced[:, 0, 0].data),
             [14, 140]
@@ -31,17 +32,31 @@ class CubesTester(unittest.TestCase):
         # TODO improve file check
         # xarray tests
         out_filename = "out.tif"
-        oeop.save_result(self.test_data.xr_data_3d, out_filename)
-
+        reduced = oeop.reduce_dimension(self.test_data.xr_data_3d, reducer=oeop.min, dimension='time')
+        oeop.save_result(reduced, out_filename)
         assert os.path.exists(out_filename)
         os.remove(out_filename)
-
+        
+        reduced = oeop.reduce_dimension(self.test_data.xr_data_4d, reducer=oeop.min, dimension='time')
+        print('reduced:',reduced)
+        oeop.save_result(reduced, out_filename)
+        assert os.path.exists(out_filename)
+        os.remove(out_filename)
+        
         out_filename = "out.nc"
         oeop.save_result(self.test_data.xr_data_3d, out_filename, format='netCDF')
         assert os.path.exists(out_filename)
         os.remove(out_filename)
 
         oeop.save_result(self.test_data.xr_data_3d, format='netCDF')
+        assert os.path.exists('out.nc')
+        os.remove('out.nc')
+        
+        oeop.save_result(self.test_data.xr_data_4d, out_filename, format='netCDF')
+        assert os.path.exists('out.nc')
+        os.remove('out.nc')
+        
+        oeop.save_result(self.test_data.xr_data_4d, format='netCDF')
         assert os.path.exists('out.nc')
         os.remove('out.nc')
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from copy import deepcopy
 import openeo_processes as oeop
-
+import xarray as xr
 
 @pytest.mark.usefixtures("test_data")
 class MathTester(unittest.TestCase):


### PR DESCRIPTION
I did the following changes:
1. Aligned output dimensions with 'x','y','t' for netCDF
2. Check lowercase format for netCDF, allowing 'netCDF', 'NETCDF' etc.
3. netCDFs now have band names corresponding to datacube bands and not 'stack-....'
4. Allow output format to be any of 'gtiff','geotiff' checking the lowercase of the string for geoTIFF
5. geoTIFFs now have band names corresponding to datacube bands and not 'stack-....'
