### PR TITLE
Sqrt fix

### DIFF
--- a/src/openeo_processes/math.py
+++ b/src/openeo_processes/math.py
@@ -2072,7 +2072,7 @@ class Sqrt:
             The computed square roots.
 
         """
-        return data.sqrt()
+        return xr.ufuncs.sqrt(data)
 
     @staticmethod
     def exec_da():


### PR DESCRIPTION
Fixed sqrt process for Xarray:
from `data.sqrt()` (not working) to `xr.ufuncs.sqrt(data)`