### PR TITLE
Allow labels to be str in predict curve

### DIFF
--- a/src/openeo_processes/cubes.py
+++ b/src/openeo_processes/cubes.py
@@ -547,11 +547,11 @@ class PredictCurve:
             dimension = get_time_dimension_from_data(data, dimension)
             dates = data[dimension].values
             if test is None:
-                timestep = [((x - np.datetime64('1970-01-01')) / np.timedelta64(1, 's')) for x in dates]
+                timestep = [((np.datetime64(x) - np.datetime64('1970-01-01')) / np.timedelta64(1, 's')) for x in dates]
                 labels = np.array(timestep)
             else:
                 coords = labels
-                labels = [((x - np.datetime64('1970-01-01')) / np.timedelta64(1, 's')) for x in labels]
+                labels = [((np.datetime64(x) - np.datetime64('1970-01-01')) / np.timedelta64(1, 's')) for x in labels]
                 labels = np.array(labels)
         else:
             if test is None:

--- a/tests/test_cubes.py
+++ b/tests/test_cubes.py
@@ -183,6 +183,11 @@ class CubesTester(unittest.TestCase):
         predicted_t = oeop.predict_curve(xdata_t, params, func, dimension='t',
                                          labels=pd.date_range("2000-01-01", periods=24, freq='M'))
         xr.testing.assert_equal(predicted, predicted_t)
+        predicted_time = oeop.predict_curve(xdata, params, func, dimension='time',
+                                       labels=pd.date_range("2002-01-01", periods=2, freq='M'))
+        predicted_str = oeop.predict_curve(xdata, params, func, dimension='time',
+                                       labels=["2002-01-31 00:00", "2002-02-28"])
+        assert (predicted_time.values == predicted_str.values).all()
 
 
     def test_resample_cube_temporal(self):


### PR DESCRIPTION
Converts str to np.datetime in predict curve.