### PR TITLE
Remove non-installed geocube import

### DIFF
--- a/src/openeo_processes/cubes.py
+++ b/src/openeo_processes/cubes.py
@@ -24,7 +24,6 @@ except ImportError:
     CRS = None
 import xgboost as xgb
 import dask.dataframe as df
-from geocube.api.core import make_geocube
 import dask_geopandas
 from src.openeo_processes.utils import geometry_mask
 


### PR DESCRIPTION
#167 removed the geocube dependency again, but I forgot to delete this import in cubes.py, which makes jobs fail.  